### PR TITLE
Change required Forge version to latest recommended Version

### DIFF
--- a/src/main/java/me/ichun/mods/googlyeyes/common/GooglyEyes.java
+++ b/src/main/java/me/ichun/mods/googlyeyes/common/GooglyEyes.java
@@ -33,7 +33,7 @@ import java.util.Map;
 @Mod(name = GooglyEyes.name, modid = GooglyEyes.modid, version = GooglyEyes.version,
         clientSideOnly = true,
         acceptableRemoteVersions = "*",
-        dependencies = "required-after:Forge@[12.18.2.2103,)"
+        dependencies = "required-after:Forge@[12.18.2.2099,)"
 )
 public class GooglyEyes
 {


### PR DESCRIPTION
Confirmed working perfectly fine on build 2099.
This is usefull, as many players (including me) and some Modpacks often use the stable versions of Forge over the dev versions.
